### PR TITLE
Fixed missing string escape: " → ""

### DIFF
--- a/prizm.default.properties
+++ b/prizm.default.properties
@@ -376,7 +376,7 @@ prizm.debugTraceLog=
 prizm.debugTraceSeparator=\t
 
 # Quote character for trace log.
-prizm.debugTraceQuote="
+prizm.debugTraceQuote=""
 
 # Log changes to unconfirmed balances.
 prizm.debugLogUnconfirmed=false


### PR DESCRIPTION
One of the string escape cases was missing, so I replaced " with "" accordingly.

